### PR TITLE
xfs support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.1-alpine
+FROM golang:1.7.5-alpine3.5
 MAINTAINER Jason Poon <docker@jasonpoon.ca>
 
 ADD . /src

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ As the Azure CLI currently does not supporting creating a blank VHD ([azure-cli#
 
 ```
 docker build . -t create-blank-vhd
-docker run -it azure-create-vhd STORAGE_ACCOUNT_NAME STORAGE_ACCOUNT_KEY CONTAINER_NAME VHD_NAME [VHD_SIZE] [--verbose]
+docker run -it azure-create-vhd STORAGE_ACCOUNT_NAME STORAGE_ACCOUNT_KEY CONTAINER_NAME VHD_NAME [VHD_SIZE] [--fstype=type] [--verbose]
 
 Arguments:
   STORAGE_ACCOUNT_NAME  Azure storage account name
@@ -23,5 +23,7 @@ Options:
   --vhd_size N          Optional parameter denoting size in bytes of VHD (Default: 10G).
                         Suffixes "k" or "K" (kilobyte, 1024) "M" (megabyte, 1024k) 
                         "G" (gigabyte, 1024M) and T (terabyte, 1024G) are supported.
+  --fstype=<type>       Optional parameter denoting type of filesystem to create [default: ext4].
+                        Supported filesystems: ext4, xfs.
   --verbose             Output logs (Default: false)
   ```

--- a/create_blank_vhd.go
+++ b/create_blank_vhd.go
@@ -88,7 +88,7 @@ Options:
 	}
 
 	// Upload
-	cmdName = "azure-vhd-utils-for-go"
+	cmdName = "azure-vhd-utils"
 	cmdArgs = []string{
 		"upload",
 		"--localvhdpath=image.vhd",

--- a/create_blank_vhd.go
+++ b/create_blank_vhd.go
@@ -15,7 +15,7 @@ func main() {
 	usage := `
 
 Usage:
-  create_blank_vhd STORAGE_ACCOUNT_NAME STORAGE_ACCOUNT_KEY CONTAINER_NAME VHD_NAME [VHD_SIZE] [--verbose]
+  create_blank_vhd STORAGE_ACCOUNT_NAME STORAGE_ACCOUNT_KEY CONTAINER_NAME VHD_NAME [VHD_SIZE] [--fstype=<type>] [--verbose]
 
 Arguments:
   STORAGE_ACCOUNT_NAME  Azure storage account name
@@ -28,6 +28,8 @@ Options:
   --vhd_size N          Optional parameter denoting size in bytes of VHD (Default: 10G).
                         Suffixes "k" or "K" (kilobyte, 1024) "M" (megabyte, 1024k) 
                         "G" (gigabyte, 1024M) and T (terabyte, 1024G) are supported.
+  --fstype=<type>       Optional parameter denoting type of filesystem to create [default: ext4].
+                        Supported filesystems: ext4, xfs.
   --verbose             Output logs (Default: false)
 
 `
@@ -39,7 +41,15 @@ Options:
 	containerName := args["CONTAINER_NAME"].(string)
 	vhdName := args["VHD_NAME"].(string)
 	vhdSize := args["VHD_SIZE"]
+	fsType := args["--fstype"].(string)
 	isVerbose = args["--verbose"].(bool)
+
+	switch fsType {
+	case "ext4", "xfs":
+		break;
+	default:
+		panic(fmt.Sprintf("Unsupported filesystem type: '%s'", fsType));
+	}
 
 	if vhdSize == nil {
 		vhdSize = "10G"
@@ -56,8 +66,15 @@ Options:
 		os.Exit(1)
 	}
 
-	// Format disk as ext4
-	cmdName = "mkfs.ext4"
+	// Format disk
+	switch fsType {
+	case "ext4":
+		cmdName = "mkfs.ext4"
+	case "xfs":
+		cmdName = "mkfs.xfs"
+	default:
+		panic(fmt.Sprintf("Unsupported filesystem type: '%s'", fsType));
+	}
 	cmdArgs = []string{"./image.raw"}
 	if _, err = execCommand("Format disk", cmdName, cmdArgs); err != nil {
 		os.Exit(1)

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -3,7 +3,8 @@
 apk add --update --no-cache \
     git \
     ntfs-3g-progs \
-    e2fsprogs
+    e2fsprogs \
+    xfsprogs
 
 apk add qemu-img --update-cache --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/main/ --allow-untrusted
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -9,5 +9,6 @@ apk add --update --no-cache \
 
 ## Install go dependencies
 go get github.com/docopt/docopt-go
-go get github.com/Microsoft/azure-vhd-utils-for-go
-go install github.com/Microsoft/azure-vhd-utils-for-go
+go get github.com/Azure/azure-sdk-for-go/storage
+go get github.com/Microsoft/azure-vhd-utils
+go install github.com/Microsoft/azure-vhd-utils

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -2,11 +2,10 @@
 
 apk add --update --no-cache \
     git \
+    qemu-img \
     ntfs-3g-progs \
     e2fsprogs \
     xfsprogs
-
-apk add qemu-img --update-cache --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/main/ --allow-untrusted
 
 ## Install go dependencies
 go get github.com/docopt/docopt-go


### PR DESCRIPTION
Fixes #1 

In addition to xfs support I bumped alpine base image version in order to fix following error during Docker image building:

```
Executing busybox-1.24.2-r11.trigger
Executing glib-2.52.0-r0.trigger
Error relocating /usr/lib/libglib-2.0.so.0: pthread_setname_np: symbol not found
```

and update Azure dependencies in order to fix following error during Docker image building:

```
OK: 35 MiB in 39 packages
# github.com/Microsoft/azure-vhd-utils-for-go
/go/src/github.com/Microsoft/azure-vhd-utils-for-go/vhdUploadCmdHandler.go:158: cannot use blobServiceClient (type "github.com/Microsoft/azure-vhd-utils-for-go/vendor/github.com/Azure/azure-sdk-for-go/stora
ge".BlobStorageClient) as type "github.com/Microsoft/azure-vhd-utils/vendor/github.com/Azure/azure-sdk-for-go/storage".BlobStorageClient in field value
/go/src/github.com/Microsoft/azure-vhd-utils-for-go/vhdUploadCmdHandler.go:212: cannot use client (type "github.com/Microsoft/azure-vhd-utils-for-go/vendor/github.com/Azure/azure-sdk-for-go/storage".BlobSto
rageClient) as type "github.com/Microsoft/azure-vhd-utils/vendor/github.com/Azure/azure-sdk-for-go/storage".BlobStorageClient in argument to metadata.NewMetadataFromBlob
# github.com/Microsoft/azure-vhd-utils-for-go
/go/src/github.com/Microsoft/azure-vhd-utils-for-go/vhdUploadCmdHandler.go:158: cannot use blobServiceClient (type "github.com/Microsoft/azure-vhd-utils-for-go/vendor/github.com/Azure/azure-sdk-for-go/stora
ge".BlobStorageClient) as type "github.com/Microsoft/azure-vhd-utils/vendor/github.com/Azure/azure-sdk-for-go/storage".BlobStorageClient in field value
/go/src/github.com/Microsoft/azure-vhd-utils-for-go/vhdUploadCmdHandler.go:212: cannot use client (type "github.com/Microsoft/azure-vhd-utils-for-go/vendor/github.com/Azure/azure-sdk-for-go/storage".BlobSto
rageClient) as type "github.com/Microsoft/azure-vhd-utils/vendor/github.com/Azure/azure-sdk-for-go/storage".BlobStorageClient in argument to metadata.NewMetadataFromBlob
The command '/bin/sh -c /src/docker-build.sh' returned a non-zero code: 2
```

Looks like MS splitted/renamed/moved depended packages and utilities.
